### PR TITLE
Update CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,23 @@
-version: 2
-jobs:
-  build:
+version: 2.1
+
+executors:
+  node:
     docker:
-      - image: circleci/node:12.14.1
-    working_directory: ~/workspace
+      - image: cimg/node:20.15.1
+
+jobs:
+  test:
+    executor: node
     steps:
       - checkout
-
       - run:
           name: Install latest bundlewatch
           command: yarn add bundlewatch
-
       - run:
           name: Run bundlewatch check
           command: yarn bundlewatch --config config.bundlewatch.js
+
+workflows:
+  e2e:
+    jobs:
+      - test


### PR DESCRIPTION
Update the CircleCI configuration to support version 2.1 and bump the Node from 12 to 20 (LTS).